### PR TITLE
Avoid failure while installing requirements.txt on Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ wxPython
 requests
 python-pptx
 cx_Freeze
-pywin32
+pywin32; sys_platform == 'win32'


### PR DESCRIPTION
I noticed that trying to execute `pip install -r requirements.txt` fails when installing `pywin32` because obviously it's not running on a Windows OS, so I put a condition on that line to install it only if on the right OS.